### PR TITLE
SWITCHYARD-1535: Core console 1.5.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
+.idea
 .project
 .settings
 .classpath
+overlays
 target/
 .gwt/
 *.iml

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -25,8 +25,7 @@
     <parent>
         <groupId>org.jboss.as</groupId>
         <artifactId>jboss-as-console-build</artifactId>
-        <version>1.5.1.Final</version>
-        <relativePath>../../../jbossas/console/build/pom.xml</relativePath>
+        <version>1.5.4.Final</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.switchyard.console</groupId>


### PR DESCRIPTION
Migrate the Switchyard console to Core Console 1.5.4.Final. Please release a none snapshot version after this pull request was merged. As soon as a none snapshot version is available the extension can be included in the HAL master console.
