### PR TITLE
SWITCHYARD-2023: set proper gwt-maven-plugin version in console build

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -46,6 +46,10 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>gwt-maven-plugin</artifactId>
+                <!-- NOT INHERITED! :(
+                <version>${version.com.google.gwt}</version>
+                -->
+                <version>2.5.1</version>
                 <configuration>
                     <!-- fixes the web mode problem -->
                     <fragmentCount>-1</fragmentCount>

--- a/component/core/pom.xml
+++ b/component/core/pom.xml
@@ -36,6 +36,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>gwt-maven-plugin</artifactId>
+                <version>${version.com.google.gwt}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/component/soap/pom.xml
+++ b/component/soap/pom.xml
@@ -36,6 +36,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>gwt-maven-plugin</artifactId>
+                <version>${version.com.google.gwt}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/gwt/pom.xml
+++ b/gwt/pom.xml
@@ -82,6 +82,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>gwt-maven-plugin</artifactId>
+                <version>${version.com.google.gwt}</version>
                 <executions>
                     <execution>
                         <goals>


### PR DESCRIPTION
SWITCHYARD-2023: set proper gwt-maven-plugin version in console build
https://issues.jboss.org/browse/SWITCHYARD-2023
